### PR TITLE
Integrating the new DD Package version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/circuits/* linguist-vendored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
@@ -39,6 +40,7 @@ jobs:
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14...3.19)
 
 project(qcec
         LANGUAGES CXX
-        VERSION 1.8.1
+        VERSION 1.9.0
         DESCRIPTION "QCEC - A JKQ tool for Quantum Circuit Equivalence Checking"
         )
 

--- a/apps/sim_app.cpp
+++ b/apps/sim_app.cpp
@@ -183,16 +183,16 @@ int main(int argc, char** argv) {
                     gates_to_modify = std::stoull(cmd);
 
                     for (auto k = 0u; k < gates_to_modify; ++k) {
-                        auto target   = rng() % qc2.getNqubits();
-                        auto control0 = qc::Control(rng() % qc2.getNqubits());
+                        auto target   = static_cast<dd::Qubit>(rng() % qc2.getNqubits());
+                        auto control0 = dd::Control{static_cast<dd::Qubit>(rng() % qc2.getNqubits())};
                         while (control0.qubit == target) {
-                            control0 = qc::Control(rng() % qc2.getNqubits());
+                            control0 = dd::Control{static_cast<dd::Qubit>(rng() % qc2.getNqubits())};
                         }
-                        auto control1 = qc::Control(rng() % qc2.getNqubits());
+                        auto control1 = dd::Control{static_cast<dd::Qubit>(rng() % qc2.getNqubits())};
                         while (control1.qubit == target || control1.qubit == control0.qubit) {
-                            control1 = qc::Control(rng() % qc2.getNqubits());
+                            control1 = dd::Control{static_cast<dd::Qubit>(rng() % qc2.getNqubits())};
                         }
-                        qc2.insert<std::unique_ptr<qc::StandardOperation>>(qc2.begin(), std::make_unique<qc::StandardOperation>(qc2.getNqubits(), std::vector<qc::Control>{control0, control1}, target));
+                        qc2.insert<std::unique_ptr<qc::StandardOperation>>(qc2.begin(), std::make_unique<qc::StandardOperation>(qc2.getNqubits(), dd::Controls{control0, control1}, target));
                     }
                     resoss << "_"
                            << "toffFront" << gates_to_modify;
@@ -213,16 +213,16 @@ int main(int argc, char** argv) {
                     gates_to_modify = std::stoull(cmd);
 
                     for (auto k = 0u; k < gates_to_modify; ++k) {
-                        auto target   = rng() % qc2.getNqubits();
-                        auto control0 = qc::Control(rng() % qc2.getNqubits());
+                        auto target   = static_cast<dd::Qubit>(rng() % qc2.getNqubits());
+                        auto control0 = dd::Control{static_cast<dd::Qubit>(rng() % qc2.getNqubits())};
                         while (control0.qubit == target) {
-                            control0 = qc::Control(rng() % qc2.getNqubits());
+                            control0 = dd::Control{static_cast<dd::Qubit>(rng() % qc2.getNqubits())};
                         }
-                        auto control1 = qc::Control(rng() % qc2.getNqubits());
+                        auto control1 = dd::Control{static_cast<dd::Qubit>(rng() % qc2.getNqubits())};
                         while (control1.qubit == target || control1.qubit == control0.qubit) {
-                            control1 = qc::Control(rng() % qc2.getNqubits());
+                            control1 = dd::Control{static_cast<dd::Qubit>(rng() % qc2.getNqubits())};
                         }
-                        qc2.emplace_back<qc::StandardOperation>(qc2.getNqubits(), std::vector<qc::Control>{control0, control1}, target);
+                        qc2.emplace_back<qc::StandardOperation>(qc2.getNqubits(), dd::Controls{control0, control1}, target);
                     }
                     resoss << "_"
                            << "toffRear" << gates_to_modify;

--- a/include/EquivalenceChecker.hpp
+++ b/include/EquivalenceChecker.hpp
@@ -70,7 +70,7 @@ namespace ec {
 
         std::unique_ptr<dd::Package> dd;
 
-        unsigned short nqubits = 0;
+        dd::QubitCount nqubits = 0;
 
         std::vector<bool> ancillary1{};
         std::vector<bool> ancillary2{};

--- a/include/EquivalenceCheckingResults.hpp
+++ b/include/EquivalenceCheckingResults.hpp
@@ -6,7 +6,8 @@
 #ifndef QUANTUMCIRCUITEQUIVALENCECHECKING_BASERESULTS_HPP
 #define QUANTUMCIRCUITEQUIVALENCECHECKING_BASERESULTS_HPP
 
-#include "DDpackage.h"
+#include "Definitions.hpp"
+#include "dd/Package.hpp"
 #include "nlohmann/json.hpp"
 
 #include <iostream>
@@ -50,7 +51,7 @@ namespace ec {
             std::string        name;
             unsigned short     nqubits = 0;
             unsigned long long ngates  = 0;
-            dd::Package::CVec  cexOutput{};
+            dd::CVec           cexOutput{};
 
             [[nodiscard]] std::string toString() const {
                 std::stringstream ss{};
@@ -68,7 +69,7 @@ namespace ec {
         std::string    name;
         unsigned short nqubits = 0;
 
-        Method      method;
+        Method      method{};
         Strategy    strategy    = Strategy::Proportional;
         StimuliType stimuliType = StimuliType::Classical;
 
@@ -78,9 +79,9 @@ namespace ec {
         double             verificationTime  = 0.0;
         unsigned long      maxActive         = 0;
         unsigned long long nsims             = 0;
-        dd::Package::CVec  cexInput{};
-        fp                 fidelity = 0.0;
-        dd::Edge           result   = dd::Package::DDzero;
+        dd::CVec           cexInput{};
+        dd::fp             fidelity = 0.0;
+        qc::MatrixDD       result   = qc::MatrixDD::zero;
 
         [[nodiscard]] bool consideredEquivalent() const {
             return equivalence == Equivalence::Equivalent || equivalence == Equivalence::EquivalentUpToGlobalPhase || equivalence == Equivalence::ProbablyEquivalent;
@@ -88,19 +89,19 @@ namespace ec {
 
         std::ostream& print(std::ostream& out = std::cout) const;
 
-        static void to_json(nlohmann::json& j, const dd::Package::CVec& stateVector) {
+        static void to_json(nlohmann::json& j, const dd::CVec& stateVector) {
             j = nlohmann::json::array();
             for (const auto& amp: stateVector) {
                 j.emplace_back(amp);
             }
         }
-        static void from_json(const nlohmann::json& j, dd::Package::CVec& stateVector) {
+        static void from_json(const nlohmann::json& j, dd::CVec& stateVector) {
             for (unsigned long long i = 0; i < j.size(); ++i) {
-                stateVector[i] = j.at(i).get<std::pair<fp, fp>>();
+                stateVector[i] = j.at(i).get<std::pair<dd::fp, dd::fp>>();
             }
         }
         [[nodiscard]] nlohmann::json produceJSON() const;
-        [[nodiscard]] std::string    toString() const {
+        [[nodiscard]] std::string toString() const {
             return produceJSON().dump(2);
         }
         std::ostream& printJSON(std::ostream& out = std::cout) const {
@@ -116,7 +117,7 @@ namespace ec {
             return out;
         }
         [[nodiscard]] std::string produceCSVEntry() const;
-        std::ostream&             printCSVEntry(std::ostream& out = std::cout) const {
+        std::ostream& printCSVEntry(std::ostream& out = std::cout) const {
             out << produceCSVEntry() << std::endl;
             return out;
         }

--- a/include/EquivalenceCheckingResults.hpp
+++ b/include/EquivalenceCheckingResults.hpp
@@ -67,21 +67,21 @@ namespace ec {
         CircuitInfo    circuit1{};
         CircuitInfo    circuit2{};
         std::string    name;
-        unsigned short nqubits = 0;
+        dd::QubitCount nqubits = 0;
 
         Method      method{};
         Strategy    strategy    = Strategy::Proportional;
         StimuliType stimuliType = StimuliType::Classical;
 
         // results
-        Equivalence        equivalence       = Equivalence::NoInformation;
-        double             preprocessingTime = 0.0;
-        double             verificationTime  = 0.0;
-        unsigned long      maxActive         = 0;
-        unsigned long long nsims             = 0;
-        dd::CVec           cexInput{};
-        dd::fp             fidelity = 0.0;
-        qc::MatrixDD       result   = qc::MatrixDD::zero;
+        Equivalence  equivalence       = Equivalence::NoInformation;
+        double       preprocessingTime = 0.0;
+        double       verificationTime  = 0.0;
+        std::size_t  maxActive         = 0;
+        std::size_t  nsims             = 0;
+        dd::CVec     cexInput{};
+        dd::fp       fidelity = 0.0;
+        qc::MatrixDD result   = qc::MatrixDD::zero;
 
         [[nodiscard]] bool consideredEquivalent() const {
             return equivalence == Equivalence::Equivalent || equivalence == Equivalence::EquivalentUpToGlobalPhase || equivalence == Equivalence::ProbablyEquivalent;
@@ -96,12 +96,12 @@ namespace ec {
             }
         }
         static void from_json(const nlohmann::json& j, dd::CVec& stateVector) {
-            for (unsigned long long i = 0; i < j.size(); ++i) {
+            for (std::size_t i = 0; i < j.size(); ++i) {
                 stateVector[i] = j.at(i).get<std::pair<dd::fp, dd::fp>>();
             }
         }
         [[nodiscard]] nlohmann::json produceJSON() const;
-        [[nodiscard]] std::string toString() const {
+        [[nodiscard]] std::string    toString() const {
             return produceJSON().dump(2);
         }
         std::ostream& printJSON(std::ostream& out = std::cout) const {
@@ -117,7 +117,7 @@ namespace ec {
             return out;
         }
         [[nodiscard]] std::string produceCSVEntry() const;
-        std::ostream& printCSVEntry(std::ostream& out = std::cout) const {
+        std::ostream&             printCSVEntry(std::ostream& out = std::cout) const {
             out << produceCSVEntry() << std::endl;
             return out;
         }

--- a/include/ImprovedDDEquivalenceChecker.hpp
+++ b/include/ImprovedDDEquivalenceChecker.hpp
@@ -17,11 +17,11 @@ namespace ec {
 
     class ImprovedDDEquivalenceChecker: public EquivalenceChecker {
         /// Alternate between LEFT and RIGHT applications
-        void checkNaive(dd::Edge& result, qc::permutationMap& perm1, qc::permutationMap& perm2);
+        void checkNaive(qc::MatrixDD& result, qc::Permutation& perm1, qc::Permutation& perm2);
         /// Alternate according to the gate count ratio between LEFT and RIGHT applications
-        void checkProportional(dd::Edge& result, qc::permutationMap& perm1, qc::permutationMap& perm2);
+        void checkProportional(qc::MatrixDD& result, qc::Permutation& perm1, qc::Permutation& perm2);
         /// Look-ahead LEFT and RIGHT and choose the more promising option
-        void checkLookahead(dd::Edge& result, qc::permutationMap& perm1, qc::permutationMap& perm2);
+        void checkLookahead(qc::MatrixDD& result, qc::Permutation& perm1, qc::Permutation& perm2);
 
     protected:
         /// Create the initial matrix used for the G->I<-G' scheme.
@@ -31,7 +31,7 @@ namespace ec {
         /// [1 0] for an ancillary that is present in one circuit and not acted upon in the other
         /// [0 0]
         /// \return initial matrix
-        dd::Edge createInitialMatrix();
+        qc::MatrixDD createInitialMatrix();
 
         /// Create the goal matrix used for the G->I<-G' scheme.
         /// [1 0] if the qubit is no ancillary
@@ -40,7 +40,7 @@ namespace ec {
         /// [1 0] for an ancillary that is present in either circuit
         /// [0 0]
         /// \return goal matrix
-        dd::Edge createGoalMatrix();
+        qc::MatrixDD createGoalMatrix();
 
     public:
         ImprovedDDEquivalenceChecker(qc::QuantumComputation& qc1, qc::QuantumComputation& qc2):

--- a/include/SimulationBasedEquivalenceChecker.hpp
+++ b/include/SimulationBasedEquivalenceChecker.hpp
@@ -26,26 +26,26 @@ namespace ec {
 
     class SimulationBasedEquivalenceChecker: public EquivalenceChecker {
     protected:
-        std::function<unsigned long long()>    stimuliGenerator;
+        std::function<std::size_t()>    stimuliGenerator;
         std::function<unsigned short()>        basisStateGenerator;
-        std::unordered_set<unsigned long long> stimuli;
+        std::unordered_set<std::size_t> stimuli;
 
-        unsigned short nqubits_for_stimuli = 0;
+        dd::QubitCount nqubits_for_stimuli = 0;
 
-        unsigned long long                                seed = 0;
+        std::size_t                                seed = 0;
         std::mt19937_64                                   mt;
-        std::uniform_int_distribution<unsigned long long> distribution;
+        std::uniform_int_distribution<std::size_t> distribution;
         std::uniform_int_distribution<unsigned short>     basisStateDistribution;
 
-        dd::Edge generateRandomStimulus(StimuliType type = StimuliType::Classical);
-        dd::Edge generateRandomClassicalStimulus();
-        dd::Edge generateRandomLocalQuantumStimulus();
-        dd::Edge generateRandomGlobalQuantumStimulus();
-        bool     simulateWithStimulus(const dd::Edge& stimulus, EquivalenceCheckingResults& results, const Configuration& config = Configuration{});
-        void     checkWithStimulus(const dd::Edge& stimulus, EquivalenceCheckingResults& results, const Configuration& config = Configuration{});
+        qc::VectorDD generateRandomStimulus(StimuliType type = StimuliType::Classical);
+        qc::VectorDD generateRandomClassicalStimulus();
+        qc::VectorDD generateRandomLocalQuantumStimulus();
+        qc::VectorDD generateRandomGlobalQuantumStimulus();
+        bool     simulateWithStimulus(const qc::VectorDD& stimulus, EquivalenceCheckingResults& results, const Configuration& config = Configuration{});
+        void     checkWithStimulus(const qc::VectorDD& stimulus, EquivalenceCheckingResults& results, const Configuration& config = Configuration{});
 
     public:
-        SimulationBasedEquivalenceChecker(qc::QuantumComputation& qc1, qc::QuantumComputation& qc2, unsigned long seed = 0):
+        SimulationBasedEquivalenceChecker(qc::QuantumComputation& qc1, qc::QuantumComputation& qc2, std::size_t seed = 0):
             EquivalenceChecker(qc1, qc2), seed(seed) {
             method              = ec::Method::Simulation;
             nqubits_for_stimuli = qc1.getNqubitsWithoutAncillae();
@@ -60,9 +60,8 @@ namespace ec {
             } else {
                 mt.seed(seed);
             }
-            distribution     = std::uniform_int_distribution<unsigned long long>(0, static_cast<unsigned long long>(std::pow(2.L, nqubits_for_stimuli) - 1));
+            distribution     = std::uniform_int_distribution<std::size_t>(0, static_cast<std::size_t>(std::pow(2.L, nqubits_for_stimuli) - 1));
             stimuliGenerator = [&]() { return distribution(mt); };
-            dd->setMode(dd::Vector);
 
             basisStateDistribution = std::uniform_int_distribution<unsigned short>(0, 5);
             basisStateGenerator    = [&]() { return basisStateDistribution(mt); };

--- a/include/SimulationBasedEquivalenceChecker.hpp
+++ b/include/SimulationBasedEquivalenceChecker.hpp
@@ -27,22 +27,22 @@ namespace ec {
     class SimulationBasedEquivalenceChecker: public EquivalenceChecker {
     protected:
         std::function<std::size_t()>    stimuliGenerator;
-        std::function<unsigned short()>        basisStateGenerator;
+        std::function<unsigned short()> basisStateGenerator;
         std::unordered_set<std::size_t> stimuli;
 
         dd::QubitCount nqubits_for_stimuli = 0;
 
-        std::size_t                                seed = 0;
-        std::mt19937_64                                   mt;
-        std::uniform_int_distribution<std::size_t> distribution;
-        std::uniform_int_distribution<unsigned short>     basisStateDistribution;
+        std::size_t                                   seed = 0;
+        std::mt19937_64                               mt;
+        std::uniform_int_distribution<std::size_t>    distribution;
+        std::uniform_int_distribution<unsigned short> basisStateDistribution;
 
         qc::VectorDD generateRandomStimulus(StimuliType type = StimuliType::Classical);
         qc::VectorDD generateRandomClassicalStimulus();
         qc::VectorDD generateRandomLocalQuantumStimulus();
         qc::VectorDD generateRandomGlobalQuantumStimulus();
-        bool     simulateWithStimulus(const qc::VectorDD& stimulus, EquivalenceCheckingResults& results, const Configuration& config = Configuration{});
-        void     checkWithStimulus(const qc::VectorDD& stimulus, EquivalenceCheckingResults& results, const Configuration& config = Configuration{});
+        bool         simulateWithStimulus(const qc::VectorDD& stimulus, EquivalenceCheckingResults& results, const Configuration& config = Configuration{});
+        void         checkWithStimulus(const qc::VectorDD& stimulus, EquivalenceCheckingResults& results, const Configuration& config = Configuration{});
 
     public:
         SimulationBasedEquivalenceChecker(qc::QuantumComputation& qc1, qc::QuantumComputation& qc2, std::size_t seed = 0):

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ with open(README_PATH) as readme_file:
 
 setup(
     name='jkq.qcec',
-    version='1.8.1',
+    version='1.9.0',
     author='Lukas Burgholzer',
     author_email='lukas.burgholzer@jku.at',
     description='QCEC - A JKQ tool for Quantum Circuit Equivalence Checking',

--- a/src/CompilationFlowEquivalenceChecker.cpp
+++ b/src/CompilationFlowEquivalenceChecker.cpp
@@ -12,10 +12,6 @@ namespace ec {
         setupResults(results);
         results.strategy = Strategy::CompilationFlow;
 
-        if (!validInstance()) {
-            return results;
-        }
-
         auto start = std::chrono::steady_clock::now();
         runPreCheckPasses(config);
         auto endPreprocessing = std::chrono::steady_clock::now();
@@ -41,7 +37,7 @@ namespace ec {
                 auto cost2 = costFunction((*it2)->getType(), (*it2)->getControls().size());
 
                 for (unsigned long long i = 0; i < cost2 && it1 != end1; ++i) {
-                    applyGate(it1, results.result, perm1, end1, LEFT);
+                    applyGate(qc1, it1, results.result, perm1, LEFT);
                     ++it1;
 
                     // apply possible swaps
@@ -52,7 +48,7 @@ namespace ec {
                 }
 
                 for (unsigned long long i = 0; i < cost1 && it2 != end2; ++i) {
-                    applyGate(it2, results.result, perm2, end2, RIGHT);
+                    applyGate(qc2, it2, results.result, perm2, RIGHT);
                     ++it2;
 
                     // apply possible swaps
@@ -65,18 +61,18 @@ namespace ec {
         }
         // finish first circuit
         while (it1 != end1) {
-            applyGate(it1, results.result, perm1, end1, LEFT);
+            applyGate(qc1, it1, results.result, perm1, LEFT);
             ++it1;
         }
 
         // finish second circuit
         while (it2 != end2) {
-            applyGate(it2, results.result, perm2, end2, RIGHT);
+            applyGate(qc2, it2, results.result, perm2, RIGHT);
             ++it2;
         }
 
-        qc::QuantumComputation::changePermutation(results.result, perm1, output1, line, dd, LEFT);
-        qc::QuantumComputation::changePermutation(results.result, perm2, output2, line, dd, RIGHT);
+        qc::QuantumComputation::changePermutation(results.result, perm1, output1, dd, LEFT);
+        qc::QuantumComputation::changePermutation(results.result, perm2, output2, dd, RIGHT);
         results.result = dd->reduceGarbage(results.result, garbage1, LEFT);
         results.result = dd->reduceGarbage(results.result, garbage2, RIGHT);
         results.result = dd->reduceAncillae(results.result, ancillary1, LEFT);
@@ -90,7 +86,7 @@ namespace ec {
         std::chrono::duration<double> verificationTime  = endVerification - endPreprocessing;
         results.preprocessingTime                       = preprocessingTime.count();
         results.verificationTime                        = verificationTime.count();
-        results.maxActive                               = std::max(results.maxActive, dd->maxActive);
+        results.maxActive                               = std::max(results.maxActive, dd->mUniqueTable.getMaxActiveNodes());
 
         return results;
     }

--- a/src/EquivalenceChecker.cpp
+++ b/src/EquivalenceChecker.cpp
@@ -42,7 +42,7 @@ namespace ec {
     void EquivalenceChecker::setupAncillariesAndGarbage(qc::QuantumComputation& smaller_circuit, qc::QuantumComputation& larger_circuit) {
         dd::QubitCount                               nqubits_to_remove = larger_circuit.getNqubits() - smaller_circuit.getNqubits();
         std::vector<std::pair<dd::Qubit, dd::Qubit>> removed{};
-        std::vector<bool> garbage(larger_circuit.getNqubits());
+        std::vector<bool>                            garbage(larger_circuit.getNqubits());
         smaller_circuit.ancillary.resize(larger_circuit.getNqubits());
         smaller_circuit.garbage.resize(larger_circuit.getNqubits());
         for (dd::QubitCount i = 0; i < nqubits_to_remove; ++i) {

--- a/src/EquivalenceChecker.cpp
+++ b/src/EquivalenceChecker.cpp
@@ -10,11 +10,6 @@ namespace ec {
 
     EquivalenceChecker::EquivalenceChecker(qc::QuantumComputation& qc1, qc::QuantumComputation& qc2):
         qc1(qc1), qc2(qc2) {
-        dd = std::make_unique<dd::Package>();
-        dd->setMode(dd::Matrix);
-
-        line.fill(qc::LINE_DEFAULT);
-
         // currently this modifies the underlying quantum circuits
         // in the future this might want to be avoided
         qc1.stripIdleQubits();
@@ -38,158 +33,123 @@ namespace ec {
             std::cerr << "[QCEC] Warning: circuits have different number of primary inputs! Proceed with caution!" << std::endl;
         }
         nqubits = qc1.getNqubitsWithoutAncillae() + std::max(qc1.getNancillae(), qc2.getNancillae());
+        dd      = std::make_unique<dd::Package>(nqubits);
 
         fixOutputPermutationMismatch(smaller_circuit);
         method = Method::Reference;
     }
 
     void EquivalenceChecker::setupAncillariesAndGarbage(qc::QuantumComputation& smaller_circuit, qc::QuantumComputation& larger_circuit) {
-        if (std::max(qc1.getNqubits(), qc2.getNqubits()) <= qc::MAX_QUBITS) {
-            unsigned short                                nqubits_to_remove = larger_circuit.getNqubits() - smaller_circuit.getNqubits();
-            std::vector<std::pair<unsigned short, short>> removed{};
-            std::bitset<qc::MAX_QUBITS>                   garbage{};
-            for (unsigned short i = 0; i < nqubits_to_remove; ++i) {
-                auto logical_qubit_index = qc::QuantumComputation::getHighestLogicalQubitIndex(larger_circuit.initialLayout);
-                smaller_circuit.setLogicalQubitAncillary(logical_qubit_index);
+        dd::QubitCount                               nqubits_to_remove = larger_circuit.getNqubits() - smaller_circuit.getNqubits();
+        std::vector<std::pair<dd::Qubit, dd::Qubit>> removed{};
+        std::vector<bool> garbage(larger_circuit.getNqubits());
+        smaller_circuit.ancillary.resize(larger_circuit.getNqubits());
+        smaller_circuit.garbage.resize(larger_circuit.getNqubits());
+        for (dd::QubitCount i = 0; i < nqubits_to_remove; ++i) {
+            auto logical_qubit_index = qc::QuantumComputation::getHighestLogicalQubitIndex(larger_circuit.initialLayout);
+            smaller_circuit.setLogicalQubitAncillary(logical_qubit_index);
 
-                // store whether qubit was garbage
-                garbage[logical_qubit_index] = larger_circuit.logicalQubitIsGarbage(logical_qubit_index);
-                removed.push_back(larger_circuit.removeQubit(logical_qubit_index));
-            }
+            // store whether qubit was garbage
+            garbage[logical_qubit_index] = larger_circuit.logicalQubitIsGarbage(logical_qubit_index);
+            removed.push_back(larger_circuit.removeQubit(logical_qubit_index));
+        }
 
-            for (auto it = removed.rbegin(); it != removed.rend(); ++it) {
-                larger_circuit.addAncillaryQubit(it->first, it->second);
-                smaller_circuit.setLogicalQubitGarbage(larger_circuit.getNqubits() - 1);
-                // restore garbage
-                if (garbage[larger_circuit.getNqubits() - 1]) {
-                    larger_circuit.setLogicalQubitGarbage(larger_circuit.getNqubits() - 1);
-                }
+        for (auto it = removed.rbegin(); it != removed.rend(); ++it) {
+            larger_circuit.addAncillaryQubit(it->first, it->second);
+            smaller_circuit.setLogicalQubitGarbage(static_cast<dd::Qubit>(larger_circuit.getNqubits() - 1));
+            // restore garbage
+            if (garbage[larger_circuit.getNqubits() - 1]) {
+                larger_circuit.setLogicalQubitGarbage(static_cast<dd::Qubit>(larger_circuit.getNqubits() - 1));
             }
         }
     }
 
     void EquivalenceChecker::fixOutputPermutationMismatch(qc::QuantumComputation& circuit) {
-        if (std::max(qc1.getNqubits(), qc2.getNqubits()) <= qc::MAX_QUBITS) {
-            // Try to fix potential mismatches in output permutations
-            auto& smaller_initial   = qc1.getNqubits() > qc2.getNqubits() ? initial2 : initial1;
-            auto& larger_output     = qc1.getNqubits() > qc2.getNqubits() ? output1 : output2;
-            auto& smaller_output    = qc1.getNqubits() > qc2.getNqubits() ? output2 : output1;
-            auto& smaller_ancillary = qc1.getNqubits() > qc2.getNqubits() ? ancillary2 : ancillary1;
-            auto& larger_garbage    = qc1.getNqubits() > qc2.getNqubits() ? garbage1 : garbage2;
-            auto& smaller_garbage   = qc1.getNqubits() > qc2.getNqubits() ? garbage2 : garbage1;
+        // Try to fix potential mismatches in output permutations
+        auto& smaller_initial   = qc1.getNqubits() > qc2.getNqubits() ? initial2 : initial1;
+        auto& larger_output     = qc1.getNqubits() > qc2.getNqubits() ? output1 : output2;
+        auto& smaller_output    = qc1.getNqubits() > qc2.getNqubits() ? output2 : output1;
+        auto& smaller_ancillary = qc1.getNqubits() > qc2.getNqubits() ? ancillary2 : ancillary1;
+        auto& larger_garbage    = qc1.getNqubits() > qc2.getNqubits() ? garbage1 : garbage2;
+        auto& smaller_garbage   = qc1.getNqubits() > qc2.getNqubits() ? garbage2 : garbage1;
 
-            for (const auto& o: larger_output) {
-                unsigned short output_qubit_in_larger_circuit = o.second;
-                //				unsigned short physical_qubit_in_larger_circuit = o.first;
-                //			std::cout << "Output logical qubit " << output_qubit_in_larger_circuit << " at physical qubit " << physical_qubit_in_larger_circuit;
-                unsigned short nout = 1;
-                for (int i = 0; i < output_qubit_in_larger_circuit; ++i) {
-                    if (!larger_garbage.test(i))
-                        ++nout;
+        for (const auto& o: larger_output) {
+            dd::Qubit output_qubit_in_larger_circuit = o.second;
+            //		    dd::Qubit physical_qubit_in_larger_circuit = o.first;
+            //			std::cout << "Output logical qubit " << static_cast<std::size_t>(output_qubit_in_larger_circuit) << " at physical qubit " << static_cast<std::size_t>(physical_qubit_in_larger_circuit);
+            dd::Qubit nout = 1;
+            for (dd::Qubit i = 0; i < output_qubit_in_larger_circuit; ++i) {
+                if (!larger_garbage[i])
+                    ++nout;
+            }
+            //			std::cout << " which is logical output qubit number " << static_cast<std::size_t>(nout) << std::endl;
+
+            dd::QubitCount outcount                        = nout;
+            dd::Qubit      output_qubit_in_smaller_circuit = 0;
+            bool           exists_in_smaller               = false;
+            for (dd::QubitCount i = 0; i < circuit.getNqubits(); ++i) {
+                if (!smaller_garbage[i]) {
+                    --outcount;
                 }
-                //			std::cout << " which is logical output qubit number " << nout << std::endl;
-
-                unsigned short outcount                        = nout;
-                unsigned short output_qubit_in_smaller_circuit = 0;
-                bool           exists_in_smaller               = false;
-                for (int i = 0; i < circuit.getNqubits(); ++i) {
-                    if (!smaller_garbage.test(i)) {
-                        --outcount;
-                    }
-                    if (outcount == 0) {
-                        output_qubit_in_smaller_circuit = i;
-                        exists_in_smaller               = true;
-                        break;
-                    }
+                if (outcount == 0) {
+                    output_qubit_in_smaller_circuit = static_cast<dd::Qubit>(i);
+                    exists_in_smaller               = true;
+                    break;
                 }
-                // algorithm has logical qubit that does not exist in the smaller circuit
-                if (!exists_in_smaller)
-                    continue;
+            }
+            // algorithm has logical qubit that does not exist in the smaller circuit
+            if (!exists_in_smaller)
+                continue;
 
-                //			std::cout << "This is logical qubit " << output_qubit_in_smaller_circuit << " in the smaller circuit";
-                unsigned short physical_qubit_in_smaller_circuit = 0;
-                for (const auto& out: smaller_output) {
-                    if (out.second == output_qubit_in_smaller_circuit) {
-                        physical_qubit_in_smaller_circuit = out.first;
-                        break;
-                    }
+            //			std::cout << "This is logical qubit " << static_cast<std::size_t>(output_qubit_in_smaller_circuit) << " in the smaller circuit";
+            dd::Qubit physical_qubit_in_smaller_circuit = 0;
+            for (const auto& out: smaller_output) {
+                if (out.second == output_qubit_in_smaller_circuit) {
+                    physical_qubit_in_smaller_circuit = out.first;
+                    break;
                 }
-                //			std::cout << " which is assigned to physical qubit " << physical_qubit_in_smaller_circuit << " at the end of the circuit" << std::endl;
+            }
+            //			std::cout << " which is assigned to physical qubit " << static_cast<std::size_t>(physical_qubit_in_smaller_circuit) << " at the end of the circuit" << std::endl;
 
-                if (output_qubit_in_larger_circuit != output_qubit_in_smaller_circuit) {
-                    //				std::cout << "Mismatch in the logical output qubits" << std::endl;
-                    if (smaller_ancillary.test(output_qubit_in_larger_circuit) && smaller_garbage.test(output_qubit_in_larger_circuit)) {
-                        bool           found                               = false;
-                        unsigned short physical_index_of_larger_in_smaller = 0;
-                        for (const auto& in: smaller_initial) {
-                            if (in.second == output_qubit_in_larger_circuit) {
-                                found                               = true;
-                                physical_index_of_larger_in_smaller = in.first;
+            if (output_qubit_in_larger_circuit != output_qubit_in_smaller_circuit) {
+                //				std::cout << "Mismatch in the logical output qubits" << std::endl;
+                if (smaller_ancillary[output_qubit_in_larger_circuit] && smaller_garbage[output_qubit_in_larger_circuit]) {
+                    bool      found                               = false;
+                    dd::Qubit physical_index_of_larger_in_smaller = 0;
+                    for (const auto& in: smaller_initial) {
+                        if (in.second == output_qubit_in_larger_circuit) {
+                            found                               = true;
+                            physical_index_of_larger_in_smaller = in.first;
+                            break;
+                        }
+                    }
+                    //					if (found) {
+                    //						std::cout << "Found logical qubit " << static_cast<std::size_t>(output_qubit_in_larger_circuit) << " in smaller circuit at physical qubit " << static_cast<std::size_t>(physical_index_of_larger_in_smaller) << std::endl;
+                    //						std::cout << "This qubit is idle: " << smaller_circuit.isIdleQubit(physical_index_of_larger_in_smaller) << std::endl;
+                    //					}
+                    if (!found || circuit.isIdleQubit(physical_index_of_larger_in_smaller)) {
+                        //						std::cout << "Logical qubit " << static_cast<std::size_t>(output_qubit_in_smaller_circuit) << " can be moved to logical qubit " << static_cast<std::size_t>(output_qubit_in_larger_circuit) << std::endl;
+                        for (auto& in: smaller_initial) {
+                            if (in.second == output_qubit_in_smaller_circuit) {
+                                in.second = output_qubit_in_larger_circuit;
+                                //								std::cout << "Physical qubit " << static_cast<std::size_t>(in.first) << " has been assigned logical qubit " << static_cast<std::size_t>(in.second) << " as input" << std::endl;
                                 break;
                             }
                         }
-                        //					if (found) {
-                        //						std::cout << "Found logical qubit " << output_qubit_in_larger_circuit << " in smaller circuit at physical qubit " << physical_index_of_larger_in_smaller << std::endl;
-                        //						std::cout << "This qubit is idle: " << smaller_circuit.isIdleQubit(physical_index_of_larger_in_smaller) << std::endl;
-                        //					}
-                        if (!found || circuit.isIdleQubit(physical_index_of_larger_in_smaller)) {
-                            //						std::cout << "Logical qubit " << output_qubit_in_smaller_circuit << " can be moved to logical qubit " << output_qubit_in_larger_circuit << std::endl;
-                            for (auto& in: smaller_initial) {
-                                if (in.second == output_qubit_in_smaller_circuit) {
-                                    in.second = output_qubit_in_larger_circuit;
-                                    //								std::cout << "Physical qubit " << in.first << " has been assigned logical qubit " << in.second << " as input" << std::endl;
-                                    break;
-                                }
-                            }
-                            smaller_output[physical_qubit_in_smaller_circuit] = output_qubit_in_larger_circuit;
-                            //						std::cout << "Physical qubit " << physical_qubit_in_smaller_circuit << " has been assigned logical qubit " << output_qubit_in_larger_circuit << " as output" << std::endl;
-                            smaller_ancillary[output_qubit_in_larger_circuit] = smaller_ancillary.test(output_qubit_in_smaller_circuit);
-                            smaller_ancillary.set(output_qubit_in_smaller_circuit);
-                            //						std::cout << "Logical qubit " << output_qubit_in_larger_circuit << " was assigned the ancillary status of qubit " << output_qubit_in_smaller_circuit << " (i.e., " << smaller_ancillary.test(output_qubit_in_larger_circuit) << ")" << std::endl;
-                            smaller_garbage.reset(output_qubit_in_larger_circuit);
-                            smaller_garbage.set(output_qubit_in_smaller_circuit);
-                            //						std::cout << "Logical qubit " << output_qubit_in_larger_circuit << " has been removed from the garbage outputs" << std::endl;
-                        }
-                    } else {
-                        std::cerr << "Uncorrected mismatch in output qubits!" << std::endl;
+                        smaller_output[physical_qubit_in_smaller_circuit] = output_qubit_in_larger_circuit;
+                        //						std::cout << "Physical qubit " << static_cast<std::size_t>(physical_qubit_in_smaller_circuit) << " has been assigned logical qubit " << static_cast<std::size_t>(output_qubit_in_larger_circuit) << " as output" << std::endl;
+                        smaller_ancillary[output_qubit_in_larger_circuit]  = smaller_ancillary[output_qubit_in_smaller_circuit];
+                        smaller_ancillary[output_qubit_in_smaller_circuit] = true;
+                        //						std::cout << "Logical qubit " << static_cast<std::size_t>(output_qubit_in_larger_circuit) << " was assigned the ancillary status of qubit " << static_cast<std::size_t>(output_qubit_in_smaller_circuit) << " (i.e., " << smaller_ancillary.test(output_qubit_in_larger_circuit) << ")" << std::endl;
+                        smaller_garbage[output_qubit_in_larger_circuit]  = false;
+                        smaller_garbage[output_qubit_in_smaller_circuit] = true;
+                        //						std::cout << "Logical qubit " << static_cast<std::size_t>(output_qubit_in_larger_circuit) << " has been removed from the garbage outputs" << std::endl;
                     }
+                } else {
+                    std::cerr << "Uncorrected mismatch in output qubits!" << std::endl;
                 }
             }
         }
-    }
-
-    /// Take operation and apply it either from the left or (inverted) from the right
-    /// \param op operation to apply
-    /// \param to DD to apply the operation to
-    /// \param dir LEFT or RIGHT
-    void EquivalenceChecker::applyGate(std::unique_ptr<qc::Operation>& op, dd::Edge& to, std::map<unsigned short, unsigned short>& permutation, Direction dir) {
-        // set appropriate qubit count to generate correct DD
-        auto nq = op->getNqubits();
-        op->setNqubits(nqubits);
-
-        auto saved = to;
-        if (dir == LEFT) {
-            to = dd->multiply(op->getDD(dd, line, permutation), to);
-        } else {
-            to = dd->multiply(to, op->getInverseDD(dd, line, permutation));
-        }
-        dd->incRef(to);
-        dd->decRef(saved);
-        dd->garbageCollect();
-
-        // reset qubit count
-        op->setNqubits(nq);
-    }
-
-    void EquivalenceChecker::applyGate(decltype(qc1.begin())& opIt, dd::Edge& to, std::map<unsigned short, unsigned short>& permutation, const decltype(qc1.cend())& end, Direction dir) {
-        // Measurements at the end of the circuit are considered NOPs.
-        if ((*opIt)->getType() == qc::Measure) {
-            if (!qc::QuantumComputation::isLastOperationOnQubit(opIt, end)) {
-                throw std::invalid_argument("Intermediate measurements currently not supported. Defer your measurements to the end.");
-            }
-            return;
-        }
-        applyGate(*opIt, to, permutation, dir);
     }
 
     void EquivalenceChecker::setupResults(EquivalenceCheckingResults& results) {
@@ -211,41 +171,37 @@ namespace ec {
         EquivalenceCheckingResults results{};
         setupResults(results);
 
-        if (!validInstance()) {
-            return results;
-        }
-
         auto start = std::chrono::steady_clock::now();
         runPreCheckPasses(config);
         auto endPreprocessing = std::chrono::steady_clock::now();
 
-        qc::permutationMap perm1 = initial1;
-        dd::Edge           e     = dd->makeIdent(nqubits);
+        auto perm1 = initial1;
+        auto e     = dd->makeIdent(nqubits);
         dd->incRef(e);
         e = dd->reduceAncillae(e, ancillary1);
 
         while (it1 != end1) {
-            applyGate(it1, e, perm1, end1);
+            applyGate(qc1, it1, e, perm1);
             ++it1;
         }
-        qc::QuantumComputation::changePermutation(e, perm1, output1, line, dd);
+        qc::QuantumComputation::changePermutation(e, perm1, output1, dd);
         e = dd->reduceAncillae(e, ancillary1);
         e = dd->reduceGarbage(e, garbage1);
 
-        qc::permutationMap perm2 = initial2;
-        dd::Edge           f     = dd->makeIdent(nqubits);
+        auto perm2 = initial2;
+        auto f     = dd->makeIdent(nqubits);
         dd->incRef(f);
         f = dd->reduceAncillae(f, ancillary2);
 
         while (it2 != end2) {
-            applyGate(it2, f, perm2, end2);
+            applyGate(qc2, it2, f, perm2);
             ++it2;
         }
-        qc::QuantumComputation::changePermutation(f, perm2, output2, line, dd);
+        qc::QuantumComputation::changePermutation(f, perm2, output2, dd);
         f = dd->reduceAncillae(f, ancillary2);
         f = dd->reduceGarbage(f, garbage2);
 
-        results.maxActive = dd->maxActive;
+        results.maxActive = dd->mUniqueTable.getMaxActiveNodes();
 
         results.equivalence = equals(e, f);
         if (results.equivalence == Equivalence::NotEquivalent) {
@@ -265,22 +221,6 @@ namespace ec {
         results.verificationTime                        = verificationTime.count();
 
         return results;
-    }
-
-    bool EquivalenceChecker::validInstance() {
-        if (qc1.getNqubits() > qc::MAX_QUBITS || qc2.getNqubits() > qc::MAX_QUBITS) {
-            std::cerr << "Circuit contains too many qubits to be manageable by QFR library" << std::endl;
-            return false;
-        }
-        return true;
-    }
-
-    Equivalence EquivalenceChecker::equals(const dd::Edge& e, const dd::Edge& f) {
-        if (e.p != f.p) return Equivalence::NotEquivalent;
-
-        if (!dd::ComplexNumbers::equals(e.w, f.w)) return Equivalence::EquivalentUpToGlobalPhase;
-
-        return Equivalence::Equivalent;
     }
 
     void EquivalenceChecker::runPreCheckPasses(const Configuration& config) {

--- a/src/EquivalenceChecker.cpp
+++ b/src/EquivalenceChecker.cpp
@@ -75,14 +75,14 @@ namespace ec {
 
         for (const auto& o: larger_output) {
             dd::Qubit output_qubit_in_larger_circuit = o.second;
-            //		    dd::Qubit physical_qubit_in_larger_circuit = o.first;
-            //			std::cout << "Output logical qubit " << static_cast<std::size_t>(output_qubit_in_larger_circuit) << " at physical qubit " << static_cast<std::size_t>(physical_qubit_in_larger_circuit);
+            // dd::Qubit physical_qubit_in_larger_circuit = o.first;
+            // std::cout << "Output logical qubit " << static_cast<std::size_t>(output_qubit_in_larger_circuit) << " at physical qubit " << static_cast<std::size_t>(physical_qubit_in_larger_circuit);
             dd::Qubit nout = 1;
             for (dd::Qubit i = 0; i < output_qubit_in_larger_circuit; ++i) {
                 if (!larger_garbage[i])
                     ++nout;
             }
-            //			std::cout << " which is logical output qubit number " << static_cast<std::size_t>(nout) << std::endl;
+            // std::cout << " which is logical output qubit number " << static_cast<std::size_t>(nout) << std::endl;
 
             dd::QubitCount outcount                        = nout;
             dd::Qubit      output_qubit_in_smaller_circuit = 0;
@@ -101,7 +101,7 @@ namespace ec {
             if (!exists_in_smaller)
                 continue;
 
-            //			std::cout << "This is logical qubit " << static_cast<std::size_t>(output_qubit_in_smaller_circuit) << " in the smaller circuit";
+            // std::cout << "This is logical qubit " << static_cast<std::size_t>(output_qubit_in_smaller_circuit) << " in the smaller circuit";
             dd::Qubit physical_qubit_in_smaller_circuit = 0;
             for (const auto& out: smaller_output) {
                 if (out.second == output_qubit_in_smaller_circuit) {
@@ -109,10 +109,10 @@ namespace ec {
                     break;
                 }
             }
-            //			std::cout << " which is assigned to physical qubit " << static_cast<std::size_t>(physical_qubit_in_smaller_circuit) << " at the end of the circuit" << std::endl;
+            // std::cout << " which is assigned to physical qubit " << static_cast<std::size_t>(physical_qubit_in_smaller_circuit) << " at the end of the circuit" << std::endl;
 
             if (output_qubit_in_larger_circuit != output_qubit_in_smaller_circuit) {
-                //				std::cout << "Mismatch in the logical output qubits" << std::endl;
+                // std::cout << "Mismatch in the logical output qubits" << std::endl;
                 if (smaller_ancillary[output_qubit_in_larger_circuit] && smaller_garbage[output_qubit_in_larger_circuit]) {
                     bool      found                               = false;
                     dd::Qubit physical_index_of_larger_in_smaller = 0;
@@ -123,27 +123,27 @@ namespace ec {
                             break;
                         }
                     }
-                    //					if (found) {
-                    //						std::cout << "Found logical qubit " << static_cast<std::size_t>(output_qubit_in_larger_circuit) << " in smaller circuit at physical qubit " << static_cast<std::size_t>(physical_index_of_larger_in_smaller) << std::endl;
-                    //						std::cout << "This qubit is idle: " << smaller_circuit.isIdleQubit(physical_index_of_larger_in_smaller) << std::endl;
-                    //					}
+                    if (found) {
+                        // std::cout << "Found logical qubit " << static_cast<std::size_t>(output_qubit_in_larger_circuit) << " in smaller circuit at physical qubit " << static_cast<std::size_t>(physical_index_of_larger_in_smaller) << std::endl;
+                        // std::cout << "This qubit is idle: " << circuit.isIdleQubit(physical_index_of_larger_in_smaller) << std::endl;
+                    }
                     if (!found || circuit.isIdleQubit(physical_index_of_larger_in_smaller)) {
-                        //						std::cout << "Logical qubit " << static_cast<std::size_t>(output_qubit_in_smaller_circuit) << " can be moved to logical qubit " << static_cast<std::size_t>(output_qubit_in_larger_circuit) << std::endl;
+                        // std::cout << "Logical qubit " << static_cast<std::size_t>(output_qubit_in_smaller_circuit) << " can be moved to logical qubit " << static_cast<std::size_t>(output_qubit_in_larger_circuit) << std::endl;
                         for (auto& in: smaller_initial) {
                             if (in.second == output_qubit_in_smaller_circuit) {
                                 in.second = output_qubit_in_larger_circuit;
-                                //								std::cout << "Physical qubit " << static_cast<std::size_t>(in.first) << " has been assigned logical qubit " << static_cast<std::size_t>(in.second) << " as input" << std::endl;
+                                // std::cout << "Physical qubit " << static_cast<std::size_t>(in.first) << " has been assigned logical qubit " << static_cast<std::size_t>(in.second) << " as input" << std::endl;
                                 break;
                             }
                         }
                         smaller_output[physical_qubit_in_smaller_circuit] = output_qubit_in_larger_circuit;
-                        //						std::cout << "Physical qubit " << static_cast<std::size_t>(physical_qubit_in_smaller_circuit) << " has been assigned logical qubit " << static_cast<std::size_t>(output_qubit_in_larger_circuit) << " as output" << std::endl;
+                        // std::cout << "Physical qubit " << static_cast<std::size_t>(physical_qubit_in_smaller_circuit) << " has been assigned logical qubit " << static_cast<std::size_t>(output_qubit_in_larger_circuit) << " as output" << std::endl;
                         smaller_ancillary[output_qubit_in_larger_circuit]  = smaller_ancillary[output_qubit_in_smaller_circuit];
                         smaller_ancillary[output_qubit_in_smaller_circuit] = true;
-                        //						std::cout << "Logical qubit " << static_cast<std::size_t>(output_qubit_in_larger_circuit) << " was assigned the ancillary status of qubit " << static_cast<std::size_t>(output_qubit_in_smaller_circuit) << " (i.e., " << smaller_ancillary.test(output_qubit_in_larger_circuit) << ")" << std::endl;
+                        // std::cout << "Logical qubit " << static_cast<std::size_t>(output_qubit_in_larger_circuit) << " was assigned the ancillary status of qubit " << static_cast<std::size_t>(output_qubit_in_smaller_circuit) << " (i.e., " << smaller_ancillary[output_qubit_in_larger_circuit] << ")" << std::endl;
                         smaller_garbage[output_qubit_in_larger_circuit]  = false;
                         smaller_garbage[output_qubit_in_smaller_circuit] = true;
-                        //						std::cout << "Logical qubit " << static_cast<std::size_t>(output_qubit_in_larger_circuit) << " has been removed from the garbage outputs" << std::endl;
+                        // std::cout << "Logical qubit " << static_cast<std::size_t>(output_qubit_in_larger_circuit) << " has been removed from the garbage outputs" << std::endl;
                     }
                 } else {
                     std::cerr << "Uncorrected mismatch in output qubits!" << std::endl;

--- a/src/ImprovedDDEquivalenceChecker.cpp
+++ b/src/ImprovedDDEquivalenceChecker.cpp
@@ -144,7 +144,7 @@ namespace ec {
     /// Look-ahead LEFT and RIGHT and choose the more promising option
     void ImprovedDDEquivalenceChecker::checkLookahead(qc::MatrixDD& result, qc::Permutation& perm1, qc::Permutation& perm2) {
         qc::MatrixDD left{}, right{}, saved{};
-        bool     cachedLeft = false, cachedRight = false;
+        bool         cachedLeft = false, cachedRight = false;
 
         while (it1 != end1 && it2 != end2) {
             if (!cachedLeft) {

--- a/src/ImprovedDDEquivalenceChecker.cpp
+++ b/src/ImprovedDDEquivalenceChecker.cpp
@@ -6,12 +6,12 @@
 #include <ImprovedDDEquivalenceChecker.hpp>
 
 namespace ec {
-    dd::Edge ImprovedDDEquivalenceChecker::createInitialMatrix() {
+    qc::MatrixDD ImprovedDDEquivalenceChecker::createInitialMatrix() {
         auto e = dd->makeIdent(nqubits);
         dd->incRef(e);
 
-        std::bitset<qc::MAX_QUBITS> ancillary{};
-        for (int q = nqubits - 1; q >= 0; --q) {
+        std::vector<bool> ancillary(nqubits);
+        for (auto q = static_cast<dd::Qubit>(nqubits - 1); q >= 0; --q) {
             if (qc1.logicalQubitIsAncillary(q) && qc2.logicalQubitIsAncillary(q)) {
                 bool found1  = false;
                 bool isidle1 = false;
@@ -34,7 +34,7 @@ namespace ec {
 
                 // qubit only really exists or is acted on in one of the circuits
                 if ((found1 ^ found2) || (isidle1 ^ isidle2)) {
-                    ancillary.set(q);
+                    ancillary[q] = true;
                 }
             }
         }
@@ -42,7 +42,7 @@ namespace ec {
         return e;
     }
 
-    dd::Edge ImprovedDDEquivalenceChecker::createGoalMatrix() {
+    qc::MatrixDD ImprovedDDEquivalenceChecker::createGoalMatrix() {
         auto goalMatrix = dd->makeIdent(nqubits);
         dd->incRef(goalMatrix);
         goalMatrix = dd->reduceAncillae(goalMatrix, ancillary2, RIGHT);
@@ -57,10 +57,6 @@ namespace ec {
         EquivalenceCheckingResults results{};
         setupResults(results);
         results.strategy = config.strategy;
-
-        if (!validInstance()) {
-            return results;
-        }
 
         auto start = std::chrono::steady_clock::now();
         runPreCheckPasses(config);
@@ -86,25 +82,25 @@ namespace ec {
 
         // finish first circuit
         while (it1 != end1) {
-            applyGate(it1, results.result, perm1, end1, LEFT);
+            applyGate(qc1, it1, results.result, perm1, LEFT);
             ++it1;
         }
 
         //finish second circuit
         while (it2 != end2) {
-            applyGate(it2, results.result, perm2, end2, RIGHT);
+            applyGate(qc2, it2, results.result, perm2, RIGHT);
             ++it2;
         }
 
-        qc::QuantumComputation::changePermutation(results.result, perm1, output1, line, dd, LEFT);
-        qc::QuantumComputation::changePermutation(results.result, perm2, output2, line, dd, RIGHT);
+        qc::QuantumComputation::changePermutation(results.result, perm1, output1, dd, LEFT);
+        qc::QuantumComputation::changePermutation(results.result, perm2, output2, dd, RIGHT);
         results.result = dd->reduceGarbage(results.result, garbage1, LEFT);
         results.result = dd->reduceGarbage(results.result, garbage2, RIGHT);
         results.result = dd->reduceAncillae(results.result, ancillary1, LEFT);
         results.result = dd->reduceAncillae(results.result, ancillary2, RIGHT);
 
         results.equivalence = equals(results.result, createGoalMatrix());
-        results.maxActive   = std::max(results.maxActive, dd->maxActive);
+        results.maxActive   = std::max(results.maxActive, dd->mUniqueTable.getMaxActiveNodes());
 
         auto                          endVerification   = std::chrono::steady_clock::now();
         std::chrono::duration<double> preprocessingTime = endPreprocessing - start;
@@ -116,17 +112,17 @@ namespace ec {
     }
 
     /// Alternate between LEFT and RIGHT applications
-    void ImprovedDDEquivalenceChecker::checkNaive(dd::Edge& result, qc::permutationMap& perm1, qc::permutationMap& perm2) {
+    void ImprovedDDEquivalenceChecker::checkNaive(qc::MatrixDD& result, qc::Permutation& perm1, qc::Permutation& perm2) {
         while (it1 != end1 && it2 != end2) {
-            applyGate(it1, result, perm1, end1, LEFT);
+            applyGate(qc1, it1, result, perm1, LEFT);
             ++it1;
-            applyGate(it2, result, perm2, end2, RIGHT);
+            applyGate(qc2, it2, result, perm2, RIGHT);
             ++it2;
         }
     }
 
     /// Alternate according to the gate count ratio between LEFT and RIGHT applications
-    void ImprovedDDEquivalenceChecker::checkProportional(dd::Edge& result, qc::permutationMap& perm1, qc::permutationMap& perm2) {
+    void ImprovedDDEquivalenceChecker::checkProportional(qc::MatrixDD& result, qc::Permutation& perm1, qc::Permutation& perm2) {
         auto ratio  = static_cast<unsigned int>(std::round(
                 static_cast<double>(std::max(qc1.getNops(), qc2.getNops())) /
                 static_cast<double>(std::min(qc1.getNops(), qc2.getNops()))));
@@ -135,19 +131,19 @@ namespace ec {
 
         while (it1 != end1 && it2 != end2) {
             for (unsigned int i = 0; i < ratio1 && it1 != end1; ++i) {
-                applyGate(it1, result, perm1, end1, LEFT);
+                applyGate(qc1, it1, result, perm1, LEFT);
                 ++it1;
             }
             for (unsigned int i = 0; i < ratio2 && it2 != end2; ++i) {
-                applyGate(it2, result, perm2, end2, RIGHT);
+                applyGate(qc2, it2, result, perm2, RIGHT);
                 ++it2;
             }
         }
     }
 
     /// Look-ahead LEFT and RIGHT and choose the more promising option
-    void ImprovedDDEquivalenceChecker::checkLookahead(dd::Edge& result, qc::permutationMap& perm1, qc::permutationMap& perm2) {
-        dd::Edge left{}, right{}, saved{};
+    void ImprovedDDEquivalenceChecker::checkLookahead(qc::MatrixDD& result, qc::Permutation& perm1, qc::Permutation& perm2) {
+        qc::MatrixDD left{}, right{}, saved{};
         bool     cachedLeft = false, cachedRight = false;
 
         while (it1 != end1 && it2 != end2) {
@@ -158,7 +154,7 @@ namespace ec {
 
                 auto nq = (*it1)->getNqubits();
                 (*it1)->setNqubits(nqubits);
-                left = (*it1)->getDD(dd, line, perm1);
+                left = (*it1)->getDD(dd, perm1);
                 dd->incRef(left);
                 (*it1)->setNqubits(nq);
                 ++it1;
@@ -172,7 +168,7 @@ namespace ec {
 
                 auto nq = (*it2)->getNqubits();
                 (*it2)->setNqubits(nqubits);
-                right = (*it2)->getInverseDD(dd, line, perm2);
+                right = (*it2)->getInverseDD(dd, perm2);
                 dd->incRef(right);
                 (*it2)->setNqubits(nq);
                 ++it2;

--- a/src/SimulationBasedEquivalenceChecker.cpp
+++ b/src/SimulationBasedEquivalenceChecker.cpp
@@ -124,7 +124,7 @@ namespace ec {
         edges[1] = qc::VectorDD::zero;
 
         auto initial = stabilizer;
-        for (dd::Qubit p = 0; p < static_cast<dd::Qubit>(nqubits - nqubits_for_stimuli); p++) {
+        for (std::size_t p = 0; p < static_cast<std::size_t>(nqubits - nqubits_for_stimuli); p++) {
             edges[0] = initial;
             initial  = dd->makeDDNode(static_cast<dd::Qubit>(p + nqubits_for_stimuli), edges);
         }

--- a/test/test_general.cpp
+++ b/test/test_general.cpp
@@ -56,15 +56,7 @@ TEST_F(GeneralTest, Output) {
 
 TEST_F(GeneralTest, InvalidInstance) {
     qc_original.import("./circuits/test/test_original.real");
-    qc_alternative.import("./circuits/test/test_error.qasm");
-
-    ec::EquivalenceChecker ec(qc_original, qc_alternative);
-    auto                   results = ec.check();
-    EXPECT_EQ(results.equivalence, ec::Equivalence::NoInformation);
-
-    ec::CompilationFlowEquivalenceChecker cfec(qc_original, qc_alternative);
-    results = cfec.check();
-    EXPECT_EQ(results.equivalence, ec::Equivalence::NoInformation);
+    EXPECT_THROW(qc_alternative.import("./circuits/test/test_error.qasm"), qc::QFRException);
 }
 
 TEST_F(GeneralTest, NonUnitary) {
@@ -154,14 +146,14 @@ TEST_F(GeneralTest, RemoveDiagonalGatesBeforeMeasure) {
     unsigned short         nqubits = 1;
     qc::QuantumComputation qc1(nqubits);
     qc1.emplace_back<StandardOperation>(nqubits, 0, X);
-    qc1.emplace_back<NonUnitaryOperation>(nqubits, std::vector<unsigned short>{0}, std::vector<unsigned short>{0});
+    qc1.emplace_back<NonUnitaryOperation>(nqubits, std::vector<dd::Qubit>{0}, std::vector<std::size_t>{0});
     std::cout << qc1 << std::endl;
     std::cout << "-----------------------------" << std::endl;
 
     qc::QuantumComputation qc2(nqubits);
     qc2.emplace_back<StandardOperation>(nqubits, 0, X);
     qc2.emplace_back<StandardOperation>(nqubits, 0, Z);
-    qc2.emplace_back<NonUnitaryOperation>(nqubits, std::vector<unsigned short>{0}, std::vector<unsigned short>{0});
+    qc2.emplace_back<NonUnitaryOperation>(nqubits, std::vector<dd::Qubit>{0}, std::vector<std::size_t>{0});
     std::cout << qc2 << std::endl;
     std::cout << "-----------------------------" << std::endl;
     ec::EquivalenceChecker ec(qc1, qc2);

--- a/test/test_general.cpp
+++ b/test/test_general.cpp
@@ -244,3 +244,25 @@ TEST_F(GeneralTest, CompilationFlowFinishSecondCircuit) {
     auto                                  results = ec.check();
     EXPECT_TRUE(results.consideredEquivalent());
 }
+
+TEST_F(GeneralTest, FixOutputPermutationMismatch) {
+    qc_original.addQubitRegister(2);
+    qc_original.emplace_back<qc::StandardOperation>(2, 0, qc::X);
+    qc_original.emplace_back<qc::StandardOperation>(2, 1, qc::X);
+    qc_original.setLogicalQubitAncillary(1);
+    std::cout << qc_original << std::endl;
+
+    qc_alternative.addQubitRegister(3);
+    qc_alternative.emplace_back<qc::StandardOperation>(3, 0, qc::X);
+    qc_alternative.emplace_back<qc::StandardOperation>(3, 1, qc::I);
+    qc_alternative.emplace_back<qc::StandardOperation>(3, 2, qc::X);
+    qc_alternative.outputPermutation.erase(1);
+    qc_alternative.setLogicalQubitAncillary(1);
+    qc_alternative.setLogicalQubitGarbage(1);
+    std::cout << qc_alternative << std::endl;
+
+    ec::EquivalenceChecker ec(qc_original, qc_alternative);
+    auto                   results = ec.check();
+
+    EXPECT_TRUE(results.consideredEquivalent());
+}

--- a/test/test_general.cpp
+++ b/test/test_general.cpp
@@ -222,10 +222,10 @@ TEST_F(GeneralTest, FinishFirstCircuit) {
     qc_alternative.emplace_back<qc::StandardOperation>(1, 0, qc::X);
 
     ec::Configuration config{};
-    config.strategy = ec::Strategy::Naive;
+    config.strategy             = ec::Strategy::Naive;
     config.fuseSingleQubitGates = false;
     ec::ImprovedDDEquivalenceChecker ec(qc_original, qc_alternative);
-    auto results = ec.check(config);
+    auto                             results = ec.check(config);
     EXPECT_TRUE(results.consideredEquivalent());
 }
 
@@ -241,6 +241,6 @@ TEST_F(GeneralTest, CompilationFlowFinishSecondCircuit) {
     qc_alternative.emplace_back<qc::StandardOperation>(2, 0, qc::H);
 
     ec::CompilationFlowEquivalenceChecker ec(qc_original, qc_alternative);
-    auto results = ec.check();
+    auto                                  results = ec.check();
     EXPECT_TRUE(results.consideredEquivalent());
 }


### PR DESCRIPTION
This PR adapts the QCEC library to work with the new JKQ DD Package version released recently.
Performance of all decision diagram-based routines is expected to improve (especially those based on simulation).

✨ dynamic DD package size
✨ separate VectorDD and MatrixDD classes
⚡ improved garbage collection
⚡ improved memory allocation
⚡ improved hashing  
🔥 removed `line`
🔥 `validInstance` removed as such errors are now captured at the QFR level
⬆️ qfr
🔖 bump version
🐛 fix GitHub language statistic
💚 do not fail fast during CI