### PR TITLE
Update to newest QFR version

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,6 +1,7 @@
 ignore:
   - "extern/**/*"
   - "jkq/**/*"
+  - "test/**/*"
 
 coverage:
   range: 60..90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,19 @@
 name: CI
 
-on: 
+on:
   push:
-    branches: [master]
+    branches: [ master ]
   pull_request:
-    branches: [master]
+    branches: [ master ]
   workflow_dispatch:
 
 env:
   BUILD_TYPE: Release
+  MAKEFLAGS:  "-j2"
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   build:
@@ -16,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:
     - uses: actions/checkout@v2
@@ -24,7 +29,6 @@ jobs:
         submodules: recursive
 
     - name: Configure CMake
-      shell: bash
       run: |
          if [ "$RUNNER_OS" == "Windows" ]; then
            cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBINDINGS=ON -T "ClangCl"
@@ -33,8 +37,7 @@ jobs:
          fi  
         
     - name: Build
-      shell: bash
-      run: cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --parallel 8
+      run: cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE
 
   test:
     needs: build
@@ -50,7 +53,6 @@ jobs:
         submodules: recursive
 
     - name: Configure CMake
-      shell: bash
       run: |
          if [ "$RUNNER_OS" == "Windows" ]; then
            cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_QCEC_TESTS=ON -T "ClangCl"
@@ -59,17 +61,15 @@ jobs:
          fi  
 
     - name: Build
-      shell: bash
       run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
-          cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --parallel 8      
+          cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE
         else
-          cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qcec_test --parallel 8
+          cmake --build "${{github.workspace}}/build" --config $BUILD_TYPE --target qcec_test
         fi  
 
     - name: Test
       working-directory: ${{github.workspace}}/build/test
-      shell: bash
       run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
           cd $BUILD_TYPE
@@ -88,16 +88,13 @@ jobs:
         submodules: recursive
 
     - name: Configure CMake
-      shell: bash
       run: cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" -DCMAKE_BUILD_TYPE=Debug -DBUILD_QCEC_TESTS=ON -DBINDINGS=ON -DCOVERAGE=1
 
     - name: Build
-      shell: bash
       run: cmake --build "${{github.workspace}}/build" --config Debug --target qcec_test
 
     - name: Test
       working-directory: ${{github.workspace}}/build/test
-      shell: bash
       run: ./qcec_test
         
     - name: Upload coverage to Codecov
@@ -113,6 +110,6 @@ jobs:
           submodules: recursive
       - uses: DoozyX/clang-format-lint-action@v0.12
         with:
-          source: 'include src test jkq/qcec'
+          source: 'apps include src test jkq/qcec'
           extensions: 'h,hpp,c,cpp'
           clangFormatVersion: 12

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,8 @@ on:
 env:
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
   CIBW_BUILD:                  cp3?-*
-  CIBW_ARCHS_MACOS:            x86_64 arm64
-  CIBW_TEST_SKIP: *_arm64
+  CIBW_ARCHS_MACOS:            "x86_64 arm64"
+  CIBW_TEST_SKIP:              "*_arm64"
   CIBW_SKIP:                   "*-win32 *-manylinux_i686"
   CIBW_BUILD_VERBOSITY:        3
   CIBW_TEST_COMMAND:           "python -c \"from jkq import qcec\""

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,11 +11,13 @@ on:
 
 env:
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-  CIBW_BUILD: cp3?-*
-  CIBW_SKIP: "*-win32 *-manylinux_i686 cp35-*"
-  CIBW_BUILD_VERBOSITY: 3
-  CIBW_TEST_COMMAND: "python -c \"from jkq import qcec\""
-  CIBW_BEFORE_BUILD: "pip install cmake"
+  CIBW_BUILD:                  cp3?-*
+  CIBW_ARCHS_MACOS:            x86_64 arm64
+  CIBW_TEST_SKIP: *_arm64
+  CIBW_SKIP:                   "*-win32 *-manylinux_i686"
+  CIBW_BUILD_VERBOSITY:        3
+  CIBW_TEST_COMMAND:           "python -c \"from jkq import qcec\""
+  CIBW_BEFORE_BUILD:           "pip install cmake"
 
 jobs:
   build_wheels:
@@ -32,7 +34,7 @@ jobs:
           submodules: recursive
       - uses: ilammy/msvc-dev-cmd@v1
       - name: Build wheels
-        uses: pypa/cibuildwheel@v1.11.1
+        uses: pypa/cibuildwheel@v2.1.1
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
@@ -48,7 +50,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,13 @@ name: Deploy to PyPI
 
 on:
   release:
-    types: [published]
+    types: [ published ]
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
   workflow_dispatch:
-    
+
 env:
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
   CIBW_BUILD: cp3?-*
@@ -26,19 +30,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.8'
-
-      - name: Install dependencies
-        run: |
-             python -m pip install --upgrade pip setuptools wheel cibuildwheel==1.7.4
-
+      - uses: ilammy/msvc-dev-cmd@v1
       - name: Build wheels
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse
+        uses: pypa/cibuildwheel@v1.11.1
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
@@ -76,6 +70,7 @@ jobs:
   upload_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v2
         with:
@@ -84,5 +79,7 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@master
         with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
+          user:          __token__
+          password:      ${{ secrets.pypi_password }}
+          skip_existing: true
+          verbose:       true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.14...3.19)
+cmake_minimum_required(VERSION 3.14...3.21)
 
 project(qcec
         LANGUAGES CXX
-        VERSION 1.9.1
+        VERSION 1.10.0
         DESCRIPTION "QCEC - A JKQ tool for Quantum Circuit Equivalence Checking"
         )
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Lukas Burgholzer, Robert Wille
+Copyright (c) 2021 Lukas Burgholzer, Robert Wille
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,12 +6,9 @@ graft jkq/*
 include extern/qfr/CMakeLists.txt
 graft extern/qfr/src
 graft extern/qfr/include
-graft extern/qfr/cmake
 graft extern/qfr/jkq/qfr
 include extern/qfr/extern/dd_package/CMakeLists.txt
-graft extern/qfr/extern/dd_package/src
 graft extern/qfr/extern/dd_package/include
-graft extern/qfr/extern/dd_package/cmake
 graft extern/qfr/extern/json
 graft extern/qfr/extern/pybind11
 graft extern/qfr/extern/pybind11_json

--- a/README.md
+++ b/README.md
@@ -44,17 +44,23 @@ If you have any questions, feel free to contact us via [iic-quantum@jku.at](mail
 
 JKQ QCEC is mainly developed as a C++ library with an easy-to-use Python interface. 
 - Get the Python package
-```bash
-pip install jkq.qcec
-```
+    ```bash
+    pip install jkq.qcec
+    ```
+  In order to make the library as easy to use as possible (without compilation), we provide wheels for most common platforms (64-bit Linux, MacOS, Windows). However, in order to get the best performance out of QCEC, it is recommended to
+  build it locally from the source distribution via
+    ```bash
+    pip install --no-binary jkq.qcec
+    ```
+  This enables platform specific compiler optimizations that cannot be enabled on portable wheels.
 - Start using it in Python:
-```python
-from jkq.qcec import *
-
-config = Configuration()
-<...>  # set configuration options
-results = verify(circ1, circ2, config)
-```
+    ```python
+    from jkq.qcec import *
+    
+    config = Configuration()
+    <...>  # set configuration options
+    results = verify(circ1, circ2, config)
+    ```
 Both circuits can either be IBM Qiskit `QuantumCircuit` objects or paths to circuit files (in any of the formats listed above). 
 
 The verification procedure can be configured with the following settings and options:
@@ -244,5 +250,3 @@ If you use our tool for your research, we will be thankful if you refer to it by
 ```
 
 </details>
-
-

--- a/include/EquivalenceCheckingResults.hpp
+++ b/include/EquivalenceCheckingResults.hpp
@@ -92,12 +92,13 @@ namespace ec {
         static void to_json(nlohmann::json& j, const dd::CVec& stateVector) {
             j = nlohmann::json::array();
             for (const auto& amp: stateVector) {
-                j.emplace_back(amp);
+                j.emplace_back(std::pair{amp.real(), amp.imag()});
             }
         }
         static void from_json(const nlohmann::json& j, dd::CVec& stateVector) {
             for (std::size_t i = 0; i < j.size(); ++i) {
-                stateVector[i] = j.at(i).get<std::pair<dd::fp, dd::fp>>();
+                const auto& c  = j.at(i).get<std::pair<dd::fp, dd::fp>>();
+                stateVector[i] = std::complex<dd::fp>(c.first, c.second);
             }
         }
         [[nodiscard]] nlohmann::json produceJSON() const;

--- a/jkq/qcec/bindings.cpp
+++ b/jkq/qcec/bindings.cpp
@@ -4,11 +4,11 @@
  */
 
 #include "CompilationFlowEquivalenceChecker.hpp"
-#include "QiskitImport.hpp"
 #include "SimulationBasedEquivalenceChecker.hpp"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 #include "pybind11_json/pybind11_json.hpp"
+#include "qiskit/QuantumCircuit.hpp"
 
 namespace py = pybind11;
 namespace nl = nlohmann;
@@ -25,7 +25,7 @@ ec::EquivalenceCheckingResults verify(const py::object&        circ1,
             auto&& file1 = circ1.cast<std::string>();
             qc1.import(file1);
         } else {
-            import(qc1, circ1);
+            qc::qiskit::QuantumCircuit::import(qc1, circ1);
         }
     } catch (std::exception const& e) {
         py::print("Could not import first circuit: ", e.what());
@@ -38,7 +38,7 @@ ec::EquivalenceCheckingResults verify(const py::object&        circ1,
             auto&& file2 = circ2.cast<std::string>();
             qc2.import(file2);
         } else {
-            import(qc2, circ2);
+            qc::qiskit::QuantumCircuit::import(qc2, circ2);
         }
     } catch (std::exception const& e) {
         py::print("Could not import second circuit: ", e.what());

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ with open(README_PATH) as readme_file:
 
 setup(
     name='jkq.qcec',
-    version='1.9.1',
+    version='1.10.0',
     author='Lukas Burgholzer',
     author_email='lukas.burgholzer@jku.at',
     description='QCEC - A JKQ tool for Quantum Circuit Equivalence Checking',

--- a/test/test_general.cpp
+++ b/test/test_general.cpp
@@ -208,7 +208,8 @@ TEST_F(GeneralTest, InvalidStrategy) {
     qc_original.emplace_back<qc::StandardOperation>(1, 0, qc::X);
 
     ec::ImprovedDDEquivalenceChecker ec2(qc_original, qc_original);
-    ec::Configuration                config{.strategy = ec::Strategy::CompilationFlow};
+    ec::Configuration                config{};
+    config.strategy = ec::Strategy::CompilationFlow;
     EXPECT_THROW(ec2.check(config), std::invalid_argument);
 }
 


### PR DESCRIPTION
A lot of (mostly minor) updates have happened since the last QCEC release. This PR incorporates the latest version of the QFR submodule and subsequently the underlying DD Package into QCEC. The most notable changes are:
 - proper clearing of compute tables (iic-jku/dd_package#19)
 - complex number formatting using polar coordinates and several improvements in complex table hashing (iic-jku/dd_package#20)
 - several numerical stability updates for the underlying DD package (iic-jku/dd_package#21)
 - updated Qiskit `QuantumCircuit` import (iic-jku/qfr#7)
 - bugfixes for several optimization passes (iic-jku/qfr#9)
 - possibility of cloning `QuantumComputation` objects and shortcuts for applying gates (iic-jku/qfr#11)
 - fixes for `iSWAP` and `Peres` OpenQASM export (iic-jku/qfr#12)
 - improved `OpenQASM` parser that now supports even more gates natively (iic-jku/qfr#14)
 
Furthermore, this PR simplifies some of the CI pipeline scripts and now also builds wheels and the source distribution on every commit and PR.