### PR TITLE
Fix RZ gate bug

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ env:
   CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.15 DEPLOY=ON"
   CIBW_ARCHS_MACOS:            "x86_64 arm64"
   CIBW_TEST_SKIP:              "*_arm64"
-  CIBW_SKIP:                   "*-win32 *-manylinux_i686"
+  CIBW_SKIP: "*-win32 *-musllinux_i686"
   CIBW_BUILD_VERBOSITY:        3
   CIBW_TEST_COMMAND:           "python -c \"from jkq import qcec\""
   CIBW_BEFORE_BUILD:           "pip install cmake"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
           submodules: recursive
       - uses: ilammy/msvc-dev-cmd@v1
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.3
+        uses: pypa/cibuildwheel@v2.2.2
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ env:
   CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.15 DEPLOY=ON"
   CIBW_ARCHS_MACOS:            "x86_64 arm64"
   CIBW_TEST_SKIP:              "*_arm64"
-  CIBW_SKIP: "*-win32 *-musllinux_i686"
+  CIBW_SKIP:                   "*-win32 *-musllinux_i686 *-manylinux_i686"
   CIBW_BUILD_VERBOSITY:        3
   CIBW_TEST_COMMAND:           "python -c \"from jkq import qcec\""
   CIBW_BEFORE_BUILD:           "pip install cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14...3.21)
 
 project(qcec
         LANGUAGES CXX
-        VERSION 1.10.1
+        VERSION 1.10.2
         DESCRIPTION "QCEC - A JKQ tool for Quantum Circuit Equivalence Checking"
         )
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ with open(README_PATH) as readme_file:
 
 setup(
     name='jkq.qcec',
-    version='1.10.1',
+    version='1.10.2',
     author='Lukas Burgholzer',
     author_email='lukas.burgholzer@jku.at',
     description='QCEC - A JKQ tool for Quantum Circuit Equivalence Checking',


### PR DESCRIPTION
This PR adds a bugfix regarding the realisation of RZ gates in our underlying package (see iic-jku/dd_package#25).
This fixes issues with verifying the equivalence of circuits compiled with Qiskit using the new IBM gate set `[ry, sx cx]`.

Furthermore, it adds `musllinux` wheels to the project.

Fixes #10