### PR TITLE
Minor CI/CD Updates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
           submodules: recursive
       - uses: ilammy/msvc-dev-cmd@v1
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.2.2
+        uses: pypa/cibuildwheel@v2.3.0
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,18 +9,6 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
-env:
-  CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-  CIBW_BUILD:                  cp3*
-  CIBW_ENVIRONMENT:            "DEPLOY=ON"
-  CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.15 DEPLOY=ON"
-  CIBW_ARCHS_MACOS:            "x86_64 arm64"
-  CIBW_TEST_SKIP:              "*_arm64"
-  CIBW_SKIP:                   "*-win32 *-musllinux_i686 *-manylinux_i686"
-  CIBW_BUILD_VERBOSITY:        3
-  CIBW_TEST_COMMAND:           "python -c \"from jkq import qcec\""
-  CIBW_BEFORE_BUILD:           "pip install cmake"
-
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -48,25 +36,19 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-
       - uses: actions/setup-python@v2
         name: Install Python
         with:
           python-version: '3.9'
-
       - name: Install dependencies
-        run: |
-             python -m pip install --upgrade pip setuptools wheel
-
+        run: pip install -q build
       - name: Build sdist
-        run: python setup.py sdist
-
+        run: python -m build --sdist
       - name: Test sdist
         run: pip install --verbose dist/*.tar.gz
         env:
           CC: "gcc-10"
           CXX: "g++-10"
-
       - uses: actions/upload-artifact@v2
         with:
           path: dist/*.tar.gz
@@ -80,7 +62,6 @@ jobs:
         with:
           name: artifact
           path: dist
-
       - uses: pypa/gh-action-pypi-publish@master
         with:
           user:          __token__

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,14 @@ if (DEFINED ENV{DEPLOY})
 	message(STATUS "Setting deployment configuration to '${DEPLOY}' from environment")
 endif ()
 
+# set deployment specific options
+if (DEPLOY)
+	# build a universal macOS binary in case this is a deployment build
+	set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "" FORCE)
+	# set the macOS deployment target appropriately
+	set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "" FORCE)
+endif ()
+
 # build type settings
 set(default_build_type "Release")
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,6 @@ endif ()
 if (DEPLOY)
 	# build a universal macOS binary in case this is a deployment build
 	set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "" FORCE)
-	# set the macOS deployment target appropriately
-	set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "" FORCE)
 endif ()
 
 # build type settings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14...3.21)
+cmake_minimum_required(VERSION 3.14...3.22)
 
 project(qcec
         LANGUAGES CXX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14...3.21)
 
 project(qcec
         LANGUAGES CXX
-        VERSION 1.10.2
+        VERSION 1.10.3
         DESCRIPTION "QCEC - A JKQ tool for Quantum Circuit Equivalence Checking"
         )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ endif ()
 if (DEPLOY)
 	# build a universal macOS binary in case this is a deployment build
 	set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "" FORCE)
+	# set the macOS deployment target appropriately
+	set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "" FORCE)
 endif ()
 
 # build type settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,6 @@ build-verbosity = 3
 [tool.cibuildwheel.linux]
 
 [tool.cibuildwheel.macos]
-archs = "x86_64 arm64"
+archs = "universal2"
 
 [tool.cibuildwheel.windows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build = "cp3*"
-skip = "*-win32 *-musllinux_i686 *-manylinux_i686"
-test-skip = "*_arm64"
+skip = "*-win32 *-musllinux_i686 *-manylinux_i686 cp3{8,9,10}-macosx_x86_64"
+test-skip = "*_arm64 *_universal2:arm64"
 test-command = "python -c \"from jkq import qcec\""
 environment = { DEPLOY = "ON" }
 build-verbosity = 3
@@ -13,6 +13,7 @@ build-verbosity = 3
 [tool.cibuildwheel.linux]
 
 [tool.cibuildwheel.macos]
-archs = "universal2"
+archs = "x86_64 universal2"
+environment = { MACOSX_DEPLOYMENT_TARGET = "10.15", DEPLOY = "ON" }
 
 [tool.cibuildwheel.windows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build = "cp3*"
-skip = "*-win32 *-musllinux* *-manylinux_i686"
+skip = "*-win32 *-musllinux_i686 *-manylinux_i686"
 test-skip = "*_arm64"
 test-command = "python -c \"from jkq import qcec\""
 environment = { DEPLOY = "ON" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools", "wheel", "cmake"]
+build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+build = "cp3*"
+skip = "*-win32 *-musllinux* *-manylinux_i686"
+test-skip = "*_arm64"
+test-command = "python -c \"from jkq import qcec\""
+environment = { DEPLOY = "ON" }
+build-verbosity = 3
+
+[tool.cibuildwheel.linux]
+
+[tool.cibuildwheel.macos]
+archs = "x86_64 arm64"
+
+[tool.cibuildwheel.windows]

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ with open(README_PATH) as readme_file:
 
 setup(
     name='jkq.qcec',
-    version='1.10.2',
+    version='1.10.3',
     author='Lukas Burgholzer',
     author_email='lukas.burgholzer@jku.at',
     description='QCEC - A JKQ tool for Quantum Circuit Equivalence Checking',
@@ -96,7 +96,5 @@ setup(
         'Source': 'https://github.com/iic-jku/qcec/',
         'Tracker': 'https://github.com/iic-jku/qcec/issues',
         'Research': 'https://iic.jku.at/eda/research/quantum_verification',
-    },
-    python_requires='>=3.6',
-    setup_requires=['cmake>=3.14']
+    }
 )


### PR DESCRIPTION
This PR brings some minor improvements related to the CI/CD pipeline and Python packages:
 - 🏗️ switch to PEP 517 `pyproject.toml`
 - 🐛 🍎: deploying under macOS now produces fat binaries (i.e., for `x86_64` and `arm64` architectures). This allows to effectively build `universal2` wheels for Python 3.8 onwards and eventually makes the wheels work on M1-based Macs
 - ⬆️ updated cibuildwheel to 2.3.0
 - 🏗️ increase max CMake version to 3.22
 - 🔖 increase version to 1.10.3