### PR TITLE
🍎 Revert to building separate instead of universal binaries and wheels

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,7 @@ jobs:
           path: dist/*.tar.gz
 
   upload_pypi:
-    needs: [build_wheels, build_sdist]
+    needs: [ build_wheels, build_sdist, build_m1_wheels ]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,8 +29,23 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
 
+  build_m1_wheels:
+    name:    Build wheels for Apple Silicon
+    runs-on: macos-11
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.2.2
+        env:
+          CIBW_ARCHS_MACOS: arm64
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
   build_sdist:
-    name: Build source distribution
+    name:    Build source distribution
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,6 @@ endif ()
 
 # set deployment specific options
 if (DEPLOY)
-	# build a universal macOS binary in case this is a deployment build
-	set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "" FORCE)
 	# set the macOS deployment target appropriately
 	set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "" FORCE)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14...3.22)
 
 project(qcec
         LANGUAGES CXX
-        VERSION 1.10.3
+        VERSION 1.10.4
         DESCRIPTION "QCEC - A JKQ tool for Quantum Circuit Equivalence Checking"
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build = "cp3*"
-skip = "*-win32 *-musllinux_i686 *-manylinux_i686 cp3{8,9,10}-macosx_x86_64"
+skip = "*-win32 *-musllinux_i686 *-manylinux_i686"
 test-skip = "*_arm64 *_universal2:arm64"
 test-command = "python -c \"from jkq import qcec\""
 environment = { DEPLOY = "ON" }
@@ -13,7 +13,7 @@ build-verbosity = 3
 [tool.cibuildwheel.linux]
 
 [tool.cibuildwheel.macos]
-archs = "x86_64 universal2"
+archs = "x86_64"
 environment = { MACOSX_DEPLOYMENT_TARGET = "10.15", DEPLOY = "ON" }
 
 [tool.cibuildwheel.windows]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import platform
+import re
 import subprocess
 
 from setuptools import setup, Extension, find_namespace_packages
@@ -41,7 +42,7 @@ class CMakeBuild(build_ext):
         if platform.system() == "Windows":
             cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
             cmake_args += ['-T', 'ClangCl']
-            if sys.maxsize > 2**32:
+            if sys.maxsize > 2 ** 32:
                 cmake_args += ['-A', 'x64']
             build_args += ['--', '/m']
         else:
@@ -50,6 +51,14 @@ class CMakeBuild(build_ext):
             if cpus is None:
                 cpus = 2
             build_args += ['--', '-j{}'.format(cpus)]
+
+        # cross-compile support for macOS - respect ARCHFLAGS if set
+        if sys.platform.startswith("darwin"):
+            archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
+            if archs:
+                arch_argument = "-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))
+                print('macOS building with: ', arch_argument, flush=True)
+                cmake_args += [arch_argument]
 
         env = os.environ.copy()
         env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ with open(README_PATH) as readme_file:
 
 setup(
     name='jkq.qcec',
-    version='1.10.3',
+    version='1.10.4',
     author='Lukas Burgholzer',
     author_email='lukas.burgholzer@jku.at',
     description='QCEC - A JKQ tool for Quantum Circuit Equivalence Checking',


### PR DESCRIPTION
This PR reverts the default behaviour of building universal binaries and, in turn, universal wheels for macOS.
The main reason for this is that universal wheels are hard to create once external dependencies are involved (see, e.g., iic-jku/qmap#16) and it makes CI faster.